### PR TITLE
Add "standard pony dependencies" to CI image

### DIFF
--- a/.ci-dockerfiles/Dockerfile
+++ b/.ci-dockerfiles/Dockerfile
@@ -1,14 +1,17 @@
 FROM ponylang/ponyc:latest
 
 RUN  apt-get update && \
-  apt-get -y --force-yes install curl \
+  apt-get -y --force-yes install \
+  curl \
   git \
   jq \
   python \
   python-dev \
   python-pip \
   vim \
-  wget
+  wget \
+  libpcre2-dev \
+  libssl-dev
 
 RUN pip install --upgrade pip
 RUN pip install mkdocs


### PR DESCRIPTION
This is a short term hack fix until Corral can handle installing
as needed. http needs them as will net-ssl, regex, glob, and crypto.