### PR TITLE
local gatsby install

### DIFF
--- a/build-site.sh
+++ b/build-site.sh
@@ -9,11 +9,10 @@ echo "Preparing to install dependencies..."
 pushd site || exit 1
 
 echo "Installing dependencies..."
-npm install -g gatsby-cli
 npm install
 
 echo "Building with `gatsby build`..."
-gatsby build
+npm run build
 
 echo "Build completed!"
 


### PR DESCRIPTION
Because we have gatsby as a local dep in package.json, we don't need
to install it globally (in fact the global install just proxies to the
local anyway, so we're doing double work). the package.json has a
`build` script, which has access to all of the binaries in `node_modules/bin` including `gatsby`. We can use npm to trigger this build script.