### PR TITLE
use lodash stable sort to reverse sort version numbers

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -15,6 +15,7 @@
     "gatsby-source-filesystem": "^2.1.2",
     "gatsby-transformer-remark": "^2.6.1",
     "highlight.js": "^9.15.8",
+    "lodash": "^4.17.15",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/site/src/templates/package-page.js
+++ b/site/src/templates/package-page.js
@@ -1,5 +1,6 @@
 import React from "react"
 import { graphql, Link } from "gatsby"
+import { sortBy } from 'lodash'
 
 import Layout from "../components/layout"
 
@@ -9,7 +10,7 @@ export default ({ data, pageContext }) => {
       <div>
         <h1>{pageContext.package}</h1>
         <ul>
-          {data.versions.group.map(({ version }) => (
+          {sortBy(data.versions.group, 'version').reverse().map(({ version }) => (
             <li key={version}>
               <Link to={`/packages/${pageContext.package}/${version}`}>
                 {version}

--- a/site/yarn.lock
+++ b/site/yarn.lock
@@ -6331,7 +6331,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.11.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
+lodash@^4.11.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==


### PR DESCRIPTION
Saw the email about this so popped in a quick fix. I didn't test version numbers extensively, so we may run into something down the line that requires a different approach.

![image](https://user-images.githubusercontent.com/551247/64154782-58f2f380-cde6-11e9-981e-7b66a6c7ea56.png)
